### PR TITLE
fix: blank screen margin above netlify-cms

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -8,6 +8,9 @@ const CMS = dynamic(
   { ssr: false, loading: () => <p>Loading...</p> }
 );
 const AdminPage: React.FC = () => {
-  return <CMS />;
+    return <>
+      <div id='nc-root' />
+      <CMS />
+    </>
 };
 export default AdminPage;


### PR DESCRIPTION
Netlify cms will create an `nc-root` outside of __next div if not found, which can cause a blank screen margin above netlify-cms. This commit manually creates an 'nc-root' div inside __next to fix this issue.

![image](https://user-images.githubusercontent.com/2416493/108792497-5e389500-75bc-11eb-81c2-33c3969138f4.png)
![image](https://user-images.githubusercontent.com/2416493/108792530-74465580-75bc-11eb-861c-d9eec44c1bde.png)
